### PR TITLE
//run command improvement

### DIFF
--- a/src/main/java/devarea/Main.java
+++ b/src/main/java/devarea/Main.java
@@ -11,7 +11,7 @@ public class Main {
 
     public static final String separator = "-------------------------------------------------------------\n";
 
-    public static final boolean developing = false;
+    public static final boolean developing = true;
 
     public static final String domainName = "https://devarea.fr/";
     // public static final String domainName = "http://localhost/";

--- a/src/main/java/devarea/bot/automatical/RunHandler.java
+++ b/src/main/java/devarea/bot/automatical/RunHandler.java
@@ -2,6 +2,7 @@ package devarea.bot.automatical;
 
 import devarea.bot.Init;
 import devarea.bot.commands.inLine.Run;
+import devarea.global.cache.ChannelCache;
 import discord4j.common.util.Snowflake;
 import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.channel.TextChannel;
@@ -26,7 +27,7 @@ public class RunHandler {
             return false;
         }
 
-        TextChannel channel = (TextChannel) message.getChannel().block();
+        TextChannel channel = (TextChannel) ChannelCache.get(message.getChannelId().asString());
 
         if (channel == null) {
             return false;
@@ -43,7 +44,7 @@ public class RunHandler {
             return false;
         }
 
-        TextChannel channel = (TextChannel) message.getChannel().block();
+        TextChannel channel = (TextChannel) ChannelCache.get(message.getChannelId().asString());
         Message reply;
 
         if (channel == null || (reply = channel.getMessageById(replyId).block()) == null) {
@@ -63,7 +64,7 @@ public class RunHandler {
 
     public static void sendResponse(Message message, EmbedCreateSpec spec, boolean edit) {
         Snowflake replyId = latestMessages.get(message.getId());
-        TextChannel channel = (TextChannel) message.getChannel().block();
+        TextChannel channel = (TextChannel) ChannelCache.get(message.getChannelId().asString());
         Message reply;
 
         if (channel == null) {

--- a/src/main/java/devarea/bot/automatical/RunHandler.java
+++ b/src/main/java/devarea/bot/automatical/RunHandler.java
@@ -1,0 +1,68 @@
+package devarea.bot.automatical;
+
+import devarea.bot.Init;
+import devarea.bot.commands.inLine.Run;
+import discord4j.common.util.Snowflake;
+import discord4j.core.object.entity.Message;
+import discord4j.core.object.entity.channel.TextChannel;
+import discord4j.core.spec.EmbedCreateSpec;
+import discord4j.core.spec.MessageCreateSpec;
+import discord4j.core.spec.MessageEditSpec;
+import discord4j.rest.util.AllowedMentions;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class RunHandler {
+
+    final static int MAX_MESSAGES = 400;
+
+    private static final Map<Snowflake, Snowflake> latestMessages = new LinkedHashMap<>();
+
+    public static boolean onEdit(Message message) {
+        if (!latestMessages.containsKey(message.getId())
+                || !message.getContent().startsWith(Init.initial.prefix + "run")
+                || message.getAuthor().isEmpty()) {
+            return false;
+        }
+
+        TextChannel channel = (TextChannel) message.getChannel().block();
+
+        if (channel == null) {
+            return false;
+        }
+
+        new Run(message.getAuthor().get().asMember(Init.devarea.getId()).block(), channel, message);
+        return true;
+    }
+
+    public static void addMessage(Snowflake message, Snowflake reply) {
+        latestMessages.put(message, reply);
+        if (latestMessages.size() > MAX_MESSAGES) {
+            latestMessages.remove(latestMessages.keySet().iterator().next());
+        }
+    }
+
+    public static void sendResponse(Message message, EmbedCreateSpec spec, boolean edit) {
+        Snowflake replyId = latestMessages.get(message.getId());
+        TextChannel channel = (TextChannel) message.getChannel().block();
+        Message reply;
+
+        if (channel == null) {
+            return;
+        }
+
+        if (edit && replyId != null && (reply = channel.getMessageById(replyId).block()) != null) {
+            reply.edit(MessageEditSpec.builder().addEmbed(spec).build()).subscribe();
+        } else if (replyId == null) {
+            reply = channel.createMessage(MessageCreateSpec.builder()
+                    .addEmbed(spec)
+                    .messageReference(message.getId())
+                    .allowedMentions(AllowedMentions.suppressAll())
+                    .build()).block();
+            if (edit && reply != null) {
+                addMessage(message.getId(), reply.getId());
+            }
+        }
+    }
+}

--- a/src/main/java/devarea/bot/automatical/RunHandler.java
+++ b/src/main/java/devarea/bot/automatical/RunHandler.java
@@ -36,6 +36,24 @@ public class RunHandler {
         return true;
     }
 
+    public static boolean onDelete(Message message) {
+        Snowflake replyId = latestMessages.remove(message.getId());
+
+        if (replyId == null) {
+            return false;
+        }
+
+        TextChannel channel = (TextChannel) message.getChannel().block();
+        Message reply;
+
+        if (channel == null || (reply = channel.getMessageById(replyId).block()) == null) {
+            return false;
+        }
+
+        reply.delete().subscribe();
+        return true;
+    }
+
     public static void addMessage(Snowflake message, Snowflake reply) {
         latestMessages.put(message, reply);
         if (latestMessages.size() > MAX_MESSAGES) {

--- a/src/main/java/devarea/bot/commands/SlashCommand.java
+++ b/src/main/java/devarea/bot/commands/SlashCommand.java
@@ -1,0 +1,10 @@
+package devarea.bot.commands;
+
+import discord4j.discordjson.json.ApplicationCommandRequest;
+
+public interface SlashCommand {
+    /*
+        Implement the definition of the command for generate slash Command
+     */
+    ApplicationCommandRequest getSlashCommandDefinition();
+}

--- a/src/main/java/devarea/bot/commands/inLine/Run.java
+++ b/src/main/java/devarea/bot/commands/inLine/Run.java
@@ -62,7 +62,7 @@ public class Run extends ShortCommand {
                     .build();
 
             JudgeManager.get().executeAsync(submission).thenAccept(response -> {
-                this.sendEmbed(embedResponse(response, member), false);
+                this.sendEmbed(embedResponse(response), false);
             }).whenComplete((res, e) -> {
                 message.removeSelfReaction(ReactionEmoji.custom(Init.idLoading)).subscribe();
                 if (e != null) {
@@ -84,7 +84,7 @@ public class Run extends ShortCommand {
         try {
             Map<String, List<String>> languages = JudgeManager.get().getConfig().languages();
 
-            StringBuilder field = new StringBuilder("```");
+            StringBuilder field = new StringBuilder("```\n");
             for (Map.Entry<String, List<String>> entry : languages.entrySet()) {
                 field.append(String.format("> %s --> %s\n", entry.getKey(), String.join(", ", entry.getValue())));
             }
@@ -125,7 +125,7 @@ public class Run extends ShortCommand {
             output = " ";
         }
 
-        StringBuilder formattedOutput = new StringBuilder("```")
+        StringBuilder formattedOutput = new StringBuilder("```\n")
                 .append(output)
                 .append("```");
 
@@ -136,7 +136,7 @@ public class Run extends ShortCommand {
         embed.addField("Résultat", formattedOutput.toString(), false);
     }
 
-    private EmbedCreateSpec embedResponse(JudgeResponse response, Member member) {
+    private EmbedCreateSpec embedResponse(JudgeResponse response) {
         String author = String.format("Code de %s | %s %s",
                 member.getUsername(),
                 response.getLanguage().getName(),

--- a/src/main/java/devarea/bot/commands/inLine/Run.java
+++ b/src/main/java/devarea/bot/commands/inLine/Run.java
@@ -1,6 +1,7 @@
 package devarea.bot.commands.inLine;
 
 import devarea.bot.Init;
+import devarea.bot.automatical.RunHandler;
 import devarea.bot.commands.ShortCommand;
 import devarea.bot.presets.ColorsUsed;
 import devarea.bot.presets.TextMessage;
@@ -27,7 +28,7 @@ public class Run extends ShortCommand {
     final static int MAX_LINES = 20;
     final static int MAX_CHARS = 900;
     // Regex to extract the different parts of the message.
-    final static String PATTERN = "^(.*)\\n```(.+)\\n(?s)(.*\\S.*)```\\n?(.*)$";
+    final static Pattern PATTERN = Pattern.compile("^(.*)\\n```(.+)\\n(?s)(.*\\S.*)```\\n?(.*)$");
     final static String ZERO_WIDTH_SPACE = "\u200b";
     final static int ID_ACCEPTED = 3;
 
@@ -37,19 +38,22 @@ public class Run extends ShortCommand {
         String content = message.getContent().substring((Init.initial.prefix + "run").length());
 
         if (content.isBlank()) {
-            this.sendEmbed(TextMessage.runCommandExplain, false);
+            RunHandler.sendResponse(message, TextMessage.runCommandExplain, false);
             this.endCommand();
             return;
         }
 
         if (content.strip().equals("languages")) {
-            sendListLanguages();
+            try {
+                RunHandler.sendResponse(message, embedListLanguages(), false);
+            } catch (JudgeException e) {
+                this.sendError(e.getMessage());
+            }
             this.endCommand();
             return;
         }
 
-        Pattern pattern = Pattern.compile(PATTERN);
-        Matcher matcher = pattern.matcher(content);
+        Matcher matcher = PATTERN.matcher(content);
 
         if (matcher.find()) {
             message.addReaction(ReactionEmoji.custom(Init.idLoading)).subscribe();
@@ -62,7 +66,7 @@ public class Run extends ShortCommand {
                     .build();
 
             JudgeManager.get().executeAsync(submission).thenAccept(response -> {
-                this.sendEmbed(embedResponse(response), false);
+                RunHandler.sendResponse(message, embedResponse(response), true);
             }).whenComplete((res, e) -> {
                 message.removeSelfReaction(ReactionEmoji.custom(Init.idLoading)).subscribe();
                 if (e != null) {
@@ -80,25 +84,20 @@ public class Run extends ShortCommand {
         this.endCommand();
     }
 
-    private void sendListLanguages() {
-        try {
-            Map<String, List<String>> languages = JudgeManager.get().getConfig().languages();
+    private EmbedCreateSpec embedListLanguages() throws JudgeException {
+        Map<String, List<String>> languages = JudgeManager.get().getConfig().languages();
 
-            StringBuilder field = new StringBuilder("```\n");
-            for (Map.Entry<String, List<String>> entry : languages.entrySet()) {
-                field.append(String.format("> %s --> %s\n", entry.getKey(), String.join(", ", entry.getValue())));
-            }
-            field.append("```");
-
-            EmbedCreateSpec.Builder embed = EmbedCreateSpec.builder()
-                    .addField("Langages supportés", field.toString(), false)
-                    .color(ColorsUsed.same);
-
-            this.sendEmbed(embed.build(), false);
-
-        } catch (JudgeException e) {
-            sendError(e.getMessage());
+        StringBuilder field = new StringBuilder("```\n");
+        for (Map.Entry<String, List<String>> entry : languages.entrySet()) {
+            field.append(String.format("> %s --> %s\n", entry.getKey(), String.join(", ", entry.getValue())));
         }
+        field.append("```");
+
+        EmbedCreateSpec.Builder embed = EmbedCreateSpec.builder()
+                .addField("Langages supportés", field.toString(), false)
+                .color(ColorsUsed.same);
+
+        return embed.build();
     }
 
     private void embedCodeOutput(EmbedCreateSpec.Builder embed, String judgeMessage, String... values) {

--- a/src/main/java/devarea/bot/event/MessageDelete.java
+++ b/src/main/java/devarea/bot/event/MessageDelete.java
@@ -1,5 +1,6 @@
 package devarea.bot.event;
 
+import devarea.bot.automatical.RunHandler;
 import discord4j.core.event.domain.message.MessageDeleteEvent;
 import discord4j.core.object.entity.Message;
 
@@ -9,19 +10,14 @@ public class MessageDelete {
         try {
             if(messageDeleted.getMessage().isEmpty())
                 return;
+
             final Message message = messageDeleted.getMessage().get();
-            if (message.getAuthor().get().isBot() || messageDeleted.getGuild().block() == null)
+
+            if (message.getAuthor().isEmpty() || message.getAuthor().get().isBot() || messageDeleted.getGuild().block() == null)
                 return;
-/*
-            Init.logChannel.createMessage(msg -> msg.setEmbed(embed -> {
-                final DateTimeFormatter hours = DateTimeFormatter.ofPattern("HH:mm");
-                final DateTimeFormatter date = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-                final LocalDateTime now = LocalDateTime.now();
-                embed.setColor(ColorsUsed.same);
-                embed.setTitle("Le message de " + message.getAuthor().get().getTag() + " a été supprimé :");
-                embed.setDescription(message.getContent());
-                embed.setFooter(date.format(now) + " at " + hours.format(now) + ".", message.getAuthor().get().getAvatarUrl());
-            })).subscribe();*/
+
+            RunHandler.onDelete(message);
+
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/devarea/bot/event/MessageUpdate.java
+++ b/src/main/java/devarea/bot/event/MessageUpdate.java
@@ -1,27 +1,20 @@
 package devarea.bot.event;
 
+import devarea.bot.automatical.RunHandler;
 import discord4j.core.event.domain.message.MessageUpdateEvent;
 import discord4j.core.object.entity.Message;
 
 public class MessageUpdate {
     public static void messageUpdateFunction(MessageUpdateEvent messageUpdateEvent) {
         try {
-            /*final Message message = messageUpdateEvent.getMessage().block();
+            final Message message = messageUpdateEvent.getMessage().block();
 
-            if (message.getAuthor().get().isBot() || messageUpdateEvent.getGuildId().isEmpty())
+            if (message == null || message.getAuthor().isEmpty() || message.getAuthor().get().isBot())
                 return;
 
-/*
-            Init.logChannel.createMessage(msg -> msg.setEmbed(embed -> {
-                final DateTimeFormatter hours = DateTimeFormatter.ofPattern("HH:mm");
-                final DateTimeFormatter date = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-                final LocalDateTime now = LocalDateTime.now();
-                embed.setColor(ColorsUsed.same);
-                embed.setTitle(message.getAuthor().get().getTag() + " a édité un message :");
-                embed.setDescription(message.getContent());
-                embed.setFooter(date.format(now) + " at " + hours.format(now) + ".", message.getAuthor().get().getAvatarUrl());
-            })).subscribe();*/
-        }catch (Exception e){
+            RunHandler.onEdit(message);
+
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
This PR improve the ``//run`` command:

- It fixes incorrect response formatting if the first line is only one word long. If the first line was only one word long, it was not displayed in the bot's response.

- It adds the ability to edit recent ``//run`` commands in order to avoid resending a new message (Useful to reduce channel pollution, when there is a typo in the code for example).

- When a user deletes a recent ``//run`` command, the associated bot response is also deleted.

Feel free to contact me if you have any questions regarding this PR.


https://user-images.githubusercontent.com/67101597/179372929-fbc01578-df4c-4b0e-a49c-4a163a80d88e.mp4