### PR TITLE
Move category id to the config file

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -23,6 +23,7 @@
   "join_category": "794866947460038696",
   "missions_category": "768855535310078043",
   "general_category": "768782569209724949",
+  "assistance_category": "768783547908751380",
   "rulesAccepted_role": "768374097662312461",
   "modo_role": "777782222920744990",
   "admin_role": "768383784571240509",
@@ -31,7 +32,6 @@
   "assetsImages": {
     "xp_background": "/assets/backgroundXp.jpg",
     "profile_background": "/assets/profile_back.png",
-
     "server_logo": "/assets/logo.jpg"
   },
   "badgesImages": {

--- a/src/main/java/devarea/bot/commands/inLine/AskReward.java
+++ b/src/main/java/devarea/bot/commands/inLine/AskReward.java
@@ -30,8 +30,7 @@ public class AskReward extends ShortCommand implements SlashCommand {
     public AskReward(final Member member, final ChatInputInteractionEvent chatInteraction) {
         super(member, chatInteraction);
 
-        if (channel.getCategoryId().isEmpty() || !channel.getCategoryId().get().equals(Snowflake.of(
-                "768783547908751380"))) {
+        if (channel.getCategoryId().isEmpty() || !channel.getCategoryId().get().equals(Init.initial.assistance_category)) {
             this.replyError("Vous ne pouvez utiliser cette commande que dans les channels d'entraide");
             this.endCommand();
             return;

--- a/src/main/java/devarea/bot/commands/inLine/DevHelp.java
+++ b/src/main/java/devarea/bot/commands/inLine/DevHelp.java
@@ -19,8 +19,7 @@ public class DevHelp extends ShortCommand implements SlashCommand {
 
     public DevHelp(final Member member, final ChatInputInteractionEvent chatInteraction) {
         super(member, chatInteraction);
-        if (channel.getCategoryId().isPresent() && channel.getCategoryId().get().equals(Snowflake.of(
-                "768783547908751380"))) {
+        if (channel.getCategoryId().isPresent() && channel.getCategoryId().get().equals(Init.initial.assistance_category)) {
             if (!timer.contains(this.channel.getId())) {
                 reply(InteractionApplicationCommandCallbackSpec.builder().content("<@" + this.member.getId().asString() + ">, a demandé de " +
                         "l'aide ! <@&" + Init.initial.devHelper_role.asString() + ">.").build(), false);

--- a/src/main/java/devarea/bot/commands/inLine/GiveReward.java
+++ b/src/main/java/devarea/bot/commands/inLine/GiveReward.java
@@ -32,8 +32,7 @@ public class GiveReward extends LongCommand implements SlashCommand {
     public GiveReward(final Member member, final ChatInputInteractionEvent chatInteraction) {
         super(member, chatInteraction);
 
-        if (channel.getCategoryId().isEmpty() || !channel.getCategoryId().get().equals(Snowflake.of(
-                "768783547908751380"))) {
+        if (channel.getCategoryId().isEmpty() || !channel.getCategoryId().get().equals(Init.initial.assistance_category)) {
             this.replyError("Vous ne pouvez utiliser cette commande que dans les channels d'entraide");
             this.endCommand();
             return;

--- a/src/main/java/devarea/bot/utils/InitialData.java
+++ b/src/main/java/devarea/bot/utils/InitialData.java
@@ -43,6 +43,7 @@ public class InitialData {
     public Snowflake join_category = null;
     public Snowflake missions_category = null;
     public Snowflake general_category = null;
+    public Snowflake assistance_category = null;
 
     // Roles
     public Snowflake rulesAccepted_role = null;


### PR DESCRIPTION
This PR moves the id of the category containing all the support channels to the configuration file.

Feel free to change the variable name if it doesn't fit.