### PR TITLE
Refactor Bump handler

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -29,6 +29,7 @@
   "admin_role": "768383784571240509",
   "pingMeetup_role": "798482087224934422",
   "devHelper_role": "768497680385048596",
+  "disboard_bot": "302050872383242240",
   "assetsImages": {
     "xp_background": "/assets/backgroundXp.jpg",
     "profile_background": "/assets/profile_back.png",

--- a/src/main/java/devarea/bot/event/MessageCreate.java
+++ b/src/main/java/devarea/bot/event/MessageCreate.java
@@ -22,8 +22,10 @@ public class MessageCreate {
             if (message.getMessage().getAuthor().isEmpty())
                 return;
 
-            if (message.getMessage().getAuthor().get().getId().equals(Snowflake.of("302050872383242240")))
-                BumpHandler.getDisboardMessage(message);
+            if (message.getMessage().getAuthor().get().getId().equals(Init.initial.disboard_bot)) {
+                BumpHandler.checkBumpAvailable();
+                return;
+            }
 
             if (message.getMessage().getAuthor().get().isBot() || message.getMessage().getAuthor().get().getId().equals(Init.client.getSelfId()))
                 return;
@@ -34,8 +36,10 @@ public class MessageCreate {
             } else
                 MemberCache.use(message.getMember().get());
 
-            if (message.getMessage().getChannelId().equals(Init.initial.bump_channel) && !message.getMessage().getAuthor().get().getId().equals(Snowflake.of("302050872383242240")))
-                BumpHandler.messageInChannel(message);
+            if (message.getMessage().getChannelId().equals(Init.initial.bump_channel)) {
+                message.getMessage().delete().subscribe();
+                return;
+            }
 
             startAway(() -> XPHandler.addXpToMember(message.getMember().get()));
             if (!message.getMessage().getContent().toLowerCase(Locale.ROOT).startsWith("//admin") && CommandManager.receiveMessage(message))

--- a/src/main/java/devarea/bot/utils/InitialData.java
+++ b/src/main/java/devarea/bot/utils/InitialData.java
@@ -52,6 +52,9 @@ public class InitialData {
     public Snowflake pingMeetup_role = null;
     public Snowflake devHelper_role = null;
 
+    // Bots
+    public Snowflake disboard_bot = null;
+
     // Assets
     public HashMap<String, String> assetsImages = null;
 


### PR DESCRIPTION
- Moved Disboard bot id to the config file.
- Changed the bump handler to display a timestamp indicating when the bump will be available.
- The bot now deletes user messages in the channel bump.
- During the startup, the last message sent by the bot in the channel (if any!) is retrieved and replaced. This avoids having to delete the old message manually XD.

Feel free to edit this PR or to contact me if you have any question.